### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -18,6 +18,8 @@ on:
       - 'psalm.xml'
 
 name: mutation test
+permissions:
+  contents: read
 
 jobs:
   mutation:


### PR DESCRIPTION
Potential fix for [https://github.com/rossaddison/yii-auth-client/security/code-scanning/1](https://github.com/rossaddison/yii-auth-client/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly set the permissions to `contents: read`, which is sufficient for the operations performed in this workflow. This change ensures that the workflow adheres to the principle of least privilege and avoids granting unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
